### PR TITLE
Remove Completed tab from navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,7 +18,6 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChange }) =>
   const views = [
     { id: 'all', label: 'All Todos', icon: '📝' },
     { id: 'today', label: 'Today', icon: '⭐' },
-    { id: 'completed', label: 'Completed', icon: '✅' },
     { id: 'accomplishments', label: 'Accomplishments', icon: '🎉' },
   ];
 

--- a/src/components/ViewContainer.tsx
+++ b/src/components/ViewContainer.tsx
@@ -21,14 +21,12 @@ const ViewContainer: React.FC<ViewContainerProps> = ({
   // Refs to preserve scroll positions
   const allViewRef = useRef<HTMLDivElement>(null);
   const todayViewRef = useRef<HTMLDivElement>(null);
-  const completedViewRef = useRef<HTMLDivElement>(null);
   const accomplishmentsViewRef = useRef<HTMLDivElement>(null);
   
   // Store scroll positions when switching views
   const scrollPositions = useRef<Record<string, number>>({
     all: 0,
     today: 0,
-    completed: 0,
     accomplishments: 0
   });
 
@@ -38,7 +36,6 @@ const ViewContainer: React.FC<ViewContainerProps> = ({
       switch (view) {
         case 'all': return allViewRef.current;
         case 'today': return todayViewRef.current;
-        case 'completed': return completedViewRef.current;
         case 'accomplishments': return accomplishmentsViewRef.current;
         default: return null;
       }
@@ -70,7 +67,6 @@ const ViewContainer: React.FC<ViewContainerProps> = ({
     switch (view) {
       case 'all': return allViewRef.current;
       case 'today': return todayViewRef.current;
-      case 'completed': return completedViewRef.current;
       case 'accomplishments': return accomplishmentsViewRef.current;
       default: return null;
     }
@@ -120,24 +116,6 @@ const ViewContainer: React.FC<ViewContainerProps> = ({
         }}
       >
         <TodayView />
-      </div>
-
-      {/* Completed Todos View */}
-      <div
-        ref={completedViewRef}
-        className="absolute inset-0 overflow-auto transition-opacity duration-200"
-        style={{
-          opacity: getViewOpacity('completed'),
-          visibility: getViewVisibility('completed'),
-          pointerEvents: getViewPointerEvents('completed'),
-        }}
-      >
-        <TodoList
-          view="completed"
-          refreshTrigger={refreshTrigger}
-          newTodoId={currentView === 'completed' ? newTodoId : null}
-          onNewTodoAnimationComplete={onNewTodoAnimationComplete}
-        />
       </div>
 
       {/* Accomplishments View */}


### PR DESCRIPTION
## Overview
Removes the Completed tab from the navigation since the Accomplishments view provides a better user experience for viewing completed todos.

## Changes
- ✅ Removed Completed view from navigation tabs array
- ✅ Removed Completed view div from ViewContainer
- ✅ Updated scroll position tracking (removed completed ref)
- ✅ Cleaned up getCurrentRef switch statements

## Rationale
The Accomplishments view offers a superior experience for viewing completed todos with:
- Date grouping (Today, Yesterday, day names, formatted dates)
- Motivational stats (Today, This Week, Total)
- Better visual presentation with completion times
- More context and sense of achievement

The old simple "Completed" list view is now redundant.

## Testing
- ✅ TypeScript compilation successful
- ✅ No linter errors
- ✅ Build successful

## Files Changed
- `src/components/Navigation.tsx` (removed completed from views array)
- `src/components/ViewContainer.tsx` (removed completed view div and refs)