### PR TITLE
Fix build: UpdateTodoRequest cast and unused AuthState

### DIFF
--- a/src/hooks/useTodayViewStore.ts
+++ b/src/hooks/useTodayViewStore.ts
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useApi } from './useApi';
 import { useTodoStore } from './useTodoStore';
-import type { TodayView as TodayViewData, Todo } from '../types/todo';
+import type { TodayView as TodayViewData, Todo, UpdateTodoRequest } from '../types/todo';
 import { TODAY_VIEW_SYNC_INTERVAL_MS, TODAY_VIEW_STALE_TIME_MS, MUTATION_SETTLE_DELAY_MS } from '../constants';
 
 // Query keys for TanStack Query
@@ -137,7 +137,7 @@ export const useTodayViewStore = (options: UseTodayViewStoreOptions = {}) => {
     updateTodoInTodayView(id, updates);
     
     // Use the main todo store for the actual API call
-    const result = await updateTodo(id, updates);
+    const result = await updateTodo(id, updates as UpdateTodoRequest);
     
     // Invalidate today view to ensure consistency
     setTimeout(() => {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -10,13 +10,6 @@ export interface User {
   picture?: string;
 }
 
-/** Snapshot of the current authentication state managed by {@link AuthContext}. */
-interface AuthState {
-  user: User | null;
-  isAuthenticated: boolean;
-  isLoading: boolean;
-}
-
 /**
  * Payload returned by Google's `credential` callback after the user signs in.
  */


### PR DESCRIPTION
## Summary

- Fix `tsc -b` build error in `useTodayViewStore.ts`: cast `Partial<Todo>` to `UpdateTodoRequest` at the `updateTodo()` call site (incompatible `due_date: null` vs `undefined`)
- Remove unused `AuthState` interface from `types/auth.ts` (duplicate of the one in `AuthContext.tsx`, flagged by `noUnusedLocals`)

## Test plan

- [x] `tsc -b` passes (matches Railway build command)
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)