### PR TITLE
Send the Google ID token from the passkey client

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import { createAuthenticatedApiClient } from '../services/api';
 import type { LoginRequest } from '../services/api';
+import { setPasskeyTokenProvider } from '../services/passkeyApi';
 import { logger } from '../utils/logger';
 import {
   GOOGLE_SDK_POLL_INTERVAL_MS,
@@ -326,6 +327,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
     return null;
   };
+
+  // Hand the current Google ID token to the passkey client, the same way
+  // createAuthenticatedApiClient receives it for the todos client.
+  //
+  // Without this, passkeyApi authenticates by cookie only — and passkey
+  // ENROLLMENT is guarded by requireFreshAuth, which accepts solely authMethod
+  // 'google-id-token'. The backend sets that value only on the Bearer path, so
+  // a cookie yields 'persistent-session' and is refused. The result was that
+  // enrollment could not succeed in any state: 401 without a session cookie,
+  // 403 with one. Found during Phase 2 device testing.
+  //
+  // No dependency array, deliberately: getValidToken closes over authState, so
+  // a provider registered once at mount would keep returning that first
+  // render's token — null, permanently. Re-registering each render keeps it
+  // current, and setPasskeyTokenProvider is a cheap assignment.
+  useEffect(() => {
+    setPasskeyTokenProvider(getValidToken);
+  });
 
   // Refresh token if needed
   const refreshTokenIfNeeded = async (): Promise<void> => {

--- a/src/contexts/__tests__/AuthContext.passkeyToken.test.tsx
+++ b/src/contexts/__tests__/AuthContext.passkeyToken.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * AuthContext must hand the Google ID token to the passkey client.
+ *
+ * Deliberately a separate file from AuthContext.test.tsx: that suite has 14
+ * pre-existing failures caused by real network calls escaping into jsdom
+ * ("Cross origin http://localhost:3000 forbidden"), and this behaviour should
+ * not be reported through a harness that is already red for unrelated reasons.
+ *
+ * The defect this covers, found during passkey Phase 2 device testing: the
+ * passkey client authenticated by cookie ONLY, and enrollment is guarded by
+ * requireFreshAuth, which accepts solely authMethod 'google-id-token' — set by
+ * the backend only on the Bearer path. So passkey enrollment could never
+ * succeed: 401 with no session cookie, 403 with one. Registering the provider
+ * here is what closes that gap.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { setPasskeyTokenProvider } from '../../services/passkeyApi';
+import { AuthProvider } from '../AuthContext';
+
+// AuthProvider builds an API client and runs a session health check on mount.
+// Neither is under test here, and unmocked they reach the network.
+vi.mock('../../services/api', () => ({
+  createAuthenticatedApiClient: vi.fn(() => ({
+    getTodos: vi.fn(),
+    checkSessionHealth: vi.fn().mockResolvedValue({ authenticated: false }),
+  })),
+}));
+
+vi.mock('../../services/passkeyApi', () => ({
+  setPasskeyTokenProvider: vi.fn(),
+}));
+
+describe('AuthContext passkey token wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers a token provider with the passkey client on mount', () => {
+    render(
+      <AuthProvider>
+        <div>child</div>
+      </AuthProvider>
+    );
+
+    expect(setPasskeyTokenProvider).toHaveBeenCalled();
+    const provider = vi.mocked(setPasskeyTokenProvider).mock.calls[0][0];
+    expect(typeof provider).toBe('function');
+  });
+
+  it('the registered provider returns null while signed out', () => {
+    render(
+      <AuthProvider>
+        <div>child</div>
+      </AuthProvider>
+    );
+
+    const provider = vi.mocked(setPasskeyTokenProvider).mock.calls[0][0];
+    // No login has happened, so there is no valid Google ID token. The passkey
+    // client must then send no Authorization header at all rather than
+    // "Bearer null" — see passkeyApi.test.ts.
+    expect(provider()).toBeNull();
+  });
+});

--- a/src/services/__tests__/passkeyApi.test.ts
+++ b/src/services/__tests__/passkeyApi.test.ts
@@ -5,6 +5,7 @@ import {
   loginWithPasskey,
   listPasskeys,
   deletePasskey,
+  setPasskeyTokenProvider,
 } from '../passkeyApi';
 
 vi.mock('@simplewebauthn/browser', () => ({
@@ -188,5 +189,86 @@ describe('passkeyApi', () => {
     vi.mocked(startAuthentication).mockResolvedValue({ id: 'assertion-x' } as never);
 
     await expect(loginWithPasskey()).rejects.toThrow('No matching passkey found');
+  });
+
+  // --- Bearer token forwarding -------------------------------------------
+  //
+  // These cover the Phase 2 defect: passkeyApi was a cookie-ONLY client, so
+  // every request reached the backend with no Authorization header. Enrollment
+  // is guarded by requireFreshAuth, which accepts only authMethod
+  // 'google-id-token' — a value the backend sets solely on the Bearer path.
+  // Cookie auth yields 'persistent-session' and is refused. So without these
+  // headers there is no state in which enrollment can succeed: 401 with no
+  // cookie, 403 with one.
+
+  it('sends the Google ID token as a Bearer header when a provider is registered', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    setPasskeyTokenProvider(() => 'google-id-token-abc');
+
+    await listPasskeys();
+
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({
+      Authorization: 'Bearer google-id-token-abc',
+    });
+  });
+
+  it('sends the Bearer header on enrollment, the endpoint that requires it', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: { challenge: 'chal-enroll' } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: { verified: true, credentialId: 'cred-1' } }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(startRegistration).mockResolvedValue({ id: 'attestation-x' } as never);
+    setPasskeyTokenProvider(() => 'google-id-token-enroll');
+
+    await enrollPasskey('MacBook Touch ID');
+
+    // Both legs of the ceremony must carry it, not just the first.
+    expect(fetchMock.mock.calls[0][1].headers).toMatchObject({
+      Authorization: 'Bearer google-id-token-enroll',
+    });
+    expect(fetchMock.mock.calls[1][1].headers).toMatchObject({
+      Authorization: 'Bearer google-id-token-enroll',
+    });
+  });
+
+  it('omits the Authorization header entirely when no token is available', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    // Expired or absent Google token: getValidToken() returns null. Sending
+    // "Bearer null" would be worse than sending nothing — it would take the
+    // backend down the Bearer branch and fail there instead of falling
+    // through to the session cookie.
+    setPasskeyTokenProvider(() => null);
+
+    await listPasskeys();
+
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty('Authorization');
+  });
+
+  it('still sends cookies alongside the Bearer header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    setPasskeyTokenProvider(() => 'google-id-token-abc');
+
+    await listPasskeys();
+
+    // Login/verify establishes the session cookie, so credentials must survive.
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ credentials: 'include' });
   });
 });

--- a/src/services/passkeyApi.ts
+++ b/src/services/passkeyApi.ts
@@ -27,6 +27,34 @@ interface ApiEnvelope<T> {
   error?: { code: string; message: string };
 }
 
+/**
+ * Supplies the current Google ID token, or null when there isn't a valid one.
+ *
+ * Registered once by AuthContext, mirroring how api.ts receives `getValidToken`.
+ * Kept as a module-level provider rather than a per-call argument so the four
+ * exported functions keep their existing signatures and no call site changes.
+ */
+type TokenProvider = () => string | null;
+
+let tokenProvider: TokenProvider | null = null;
+
+export function setPasskeyTokenProvider(provider: TokenProvider): void {
+  tokenProvider = provider;
+}
+
+/**
+ * Bearer header, or nothing at all.
+ *
+ * Nothing — not `Bearer null` — when there is no token: the backend branches on
+ * the mere presence of an `Authorization` header, so a bogus one would send it
+ * down the Bearer path to fail there instead of falling through to the session
+ * cookie.
+ */
+function authHeader(): Record<string, string> {
+  const token = tokenProvider?.() ?? null;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {
     // Spread `init` FIRST, then re-assert `credentials` and merge `headers`
@@ -35,9 +63,20 @@ async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
     // override the cookie-auth guarantee this helper exists to enforce
     // (session lives in an httpOnly cookie) and would replace the headers
     // object wholesale instead of merging into it. Do not reorder.
+    //
+    // `authHeader()` goes LAST, after init.headers, for the same reason
+    // `credentials` is re-asserted: it is an auth guarantee, not a default, and
+    // must not be overridable by a caller-supplied header. Both auth paths are
+    // sent together — the Bearer token is what enrollment requires
+    // (requireFreshAuth accepts only authMethod 'google-id-token'), while the
+    // cookie is what keeps the session working once Google is gone.
     ...init,
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json', ...init.headers },
+    headers: {
+      'Content-Type': 'application/json',
+      ...init.headers,
+      ...authHeader(),
+    },
   });
 
   const body = (await response.json()) as ApiEnvelope<T>;


### PR DESCRIPTION
Fixes the defect found on the **first screen** of passkey Phase 2 device testing.

## Symptom

Signed in with Google, todos loading fine, "Manage Passkeys" showed:

> Authentication required. Provide Authorization: Bearer &lt;google-token&gt; or valid session cookie.

## Root cause

`passkeyApi.ts` was a **cookie-only client**. Compare:

| | auth |
|---|---|
| `api.ts` (todos — works) | axios, `withCredentials: true`, **plus a request interceptor injecting `Authorization: Bearer <google-id-token>`** |
| `passkeyApi.ts` (passkeys — failed) | `fetch`, `credentials: 'include'`, headers hardcoded to `{'Content-Type': 'application/json'}` — grep for `Authorization`/`Bearer`/`getToken` returned **nothing** |

With `rememberMe` defaulting to `false` (`LoginButton.tsx:18`) there was usually no session cookie either, so the backend found neither credential and returned the 401 above from `auth.ts:269`.

## The part that matters more than the 401

**Passkey enrollment could not succeed in any state.**

- Enrollment is guarded by `requireFreshAuth`, which accepts only `authMethod === 'google-id-token'` (`stepUpAuth.ts:35`).
- The backend sets that value **solely on the Bearer path** (`auth.ts:329`). A session cookie yields `'persistent-session'` (`auth.ts:169`) and is refused.
- So: **401 without a cookie, 403 `STEP_UP_REQUIRED` with one.** No path existed.

That is why no passkey had ever been enrolled anywhere — not "untried", *impossible*.

**Why every test missed it:** the backend API suites authenticate through a stub with no real middleware (recorded in the workspace drift log — *"these suites do not exercise authentication"*), and the webapp tests mock `passkeyApi` wholesale. Nobody had ever wired the real client to the real middleware. Exactly the class of bug Phase 2 exists to surface.

## Fix

`passkeyApi` accepts a token provider; `AuthContext` registers the same `getValidToken` that `api.ts` already receives. Both auth paths now travel together — Bearer for enrollment, cookie for the session.

Chosen over relaxing `ENROLLMENT_AUTH_METHODS` to accept `persistent-session`, which would undo the deliberate 2026-07-31 decision that stops a borrowed 90-day session from silently minting a durable credential.

Two details worth reviewing:

- **No token → the `Authorization` header is omitted entirely**, never `Bearer null`. The backend branches on the header's mere *presence*, so a bogus one would go down the Bearer path and fail there instead of falling through to the cookie.
- **The provider is re-registered every render, no dependency array.** `getValidToken` closes over `authState`; capturing it once at mount would pin it to that render's token — `null`, permanently. `setPasskeyTokenProvider` is a cheap assignment.

## Verification

TDD throughout — six tests, **each watched failing first**. The wiring test lives in its own file because `AuthContext.test.tsx` has 14 pre-existing failures from real network calls escaping into jsdom, and this behaviour shouldn't be reported through an already-red harness.

All three mutations caught:

| Mutation | Result |
|---|---|
| Remove the `authHeader()` spread | 2 tests redden |
| Remove the `AuthContext` registration | 2 tests redden |
| Return `Bearer null` instead of omitting | 1 test reddens |

- Webapp suite: **63 failures before, 63 after** — no regressions. Total 232 → 238, passing 169 → 175, exactly the six added.
- `tsc -b --noEmit` exit 0.

**Not verified:** that enrollment now succeeds against a real authenticator. That needs a deploy and a device — it is Task 1 of the Phase 2 plan. This PR removes the blocker; it does not prove the ceremony works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvhA2Ja2w3W7oBF8ZDJCYz
