### PR TITLE
Make signing out actually end the session

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -284,10 +284,31 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           logger.error('Failed to revoke all persistent sessions:', error);
           // Continue with logout even if session revocation fails
         }
-      } else if (authState.hasPersistentSession) {
-        logger.log('[Frontend] Logging out current session only (other devices remain signed in)');
-        // Note: We're only clearing local state, not revoking the server-side session
-        // This allows the user to stay logged in on other devices
+      } else {
+        // End THIS session server-side and clear its cookie. Other devices stay
+        // signed in — that distinction is why /auth/logout exists alongside
+        // DELETE /auth/sessions.
+        //
+        // This used to clear local state ONLY. The httpOnly
+        // `__Host-remember_token` cookie and its server-side session survived,
+        // so the next page load silently signed the user back in: a 90-day
+        // session left behind on a shared machine, and passkey enrollment made
+        // unreachable, since a cookie-restored user never holds the Google ID
+        // token enrollment requires and had no way to obtain one. Confirmed
+        // against production during Phase 2 testing.
+        //
+        // Called unconditionally rather than only when hasPersistentSession is
+        // true: that flag reflects what this tab believes, and the cookie can
+        // outlive the belief. The endpoint is a no-op without a cookie.
+        try {
+          logger.log('[Frontend] Ending current session (other devices remain signed in)');
+          const apiClient = createAuthenticatedApiClient(getValidToken, () => {});
+          await apiClient.logout();
+        } catch (error) {
+          logger.error('Failed to end current session:', error);
+          // Fall through: local state is cleared below regardless. A failed
+          // round trip must not strand the user in a signed-in browser.
+        }
       }
     } catch (error) {
       logger.error('Error during logout cleanup:', error);

--- a/src/contexts/__tests__/AuthContext.logout.test.tsx
+++ b/src/contexts/__tests__/AuthContext.logout.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Signing out must actually end the session, not just forget it locally.
+ *
+ * Separate file from AuthContext.test.tsx, which has 14 pre-existing failures
+ * from real network calls escaping into jsdom.
+ *
+ * Confirmed against production during passkey Phase 2 testing: "log out and
+ * back in" left the user signed in. logout() cleared local state but never told
+ * the server, so the httpOnly `__Host-remember_token` cookie and its session
+ * survived and the next page load silently restored the user as
+ * `persistent-session`. Two consequences — a 90-day session left behind on a
+ * shared machine, and passkey enrollment permanently unreachable, because a
+ * cookie-restored user never holds the Google ID token enrollment requires and
+ * had no way to obtain one.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createAuthenticatedApiClient } from '../../services/api';
+import { AuthProvider, useAuth } from '../AuthContext';
+
+const logoutSpy = vi.fn().mockResolvedValue({ success: true, data: { loggedOut: true } });
+const revokeAllSpy = vi.fn().mockResolvedValue({ success: true, data: { revokedCount: 2 } });
+
+vi.mock('../../services/api', () => ({
+  createAuthenticatedApiClient: vi.fn(() => ({
+    logout: logoutSpy,
+    revokeAllSessions: revokeAllSpy,
+    validatePersistentSession: vi.fn().mockResolvedValue({ success: false }),
+    checkSessionHealth: vi.fn().mockResolvedValue({ authenticated: false }),
+  })),
+}));
+
+vi.mock('../../services/passkeyApi', () => ({
+  setPasskeyTokenProvider: vi.fn(),
+}));
+
+function LogoutButton() {
+  const { logout } = useAuth();
+  return <button onClick={() => void logout()}>sign out</button>;
+}
+
+describe('AuthContext logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('tells the server to end this session', async () => {
+    render(
+      <AuthProvider>
+        <LogoutButton />
+      </AuthProvider>
+    );
+
+    screen.getByText('sign out').click();
+
+    await waitFor(() => {
+      expect(logoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('does not sign the user out everywhere', async () => {
+    render(
+      <AuthProvider>
+        <LogoutButton />
+      </AuthProvider>
+    );
+
+    screen.getByText('sign out').click();
+
+    await waitFor(() => {
+      expect(logoutSpy).toHaveBeenCalled();
+    });
+    // The user's phone must stay signed in — that distinction is the entire
+    // reason /auth/logout exists alongside DELETE /auth/sessions.
+    expect(revokeAllSpy).not.toHaveBeenCalled();
+    expect(createAuthenticatedApiClient).toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/apiLogout.test.ts
+++ b/src/services/__tests__/apiLogout.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The API client must be able to end THIS browser's session.
+ *
+ * Separate file from api.test.ts, which has pre-existing failures from axios
+ * mocking (`this.api.interceptors` undefined). This behaviour should not be
+ * reported through an already-red harness.
+ *
+ * Background: signing out only cleared local state. The httpOnly
+ * `__Host-remember_token` cookie survived and its server-side session stayed
+ * valid, so the next page load silently signed the user back in. Confirmed
+ * against production during passkey Phase 2 testing — "log out and back in"
+ * did nothing, and enrollment stayed blocked because a cookie-restored user
+ * can never obtain the Google ID token enrollment requires.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { createAuthenticatedApiClient } from '../api';
+
+vi.mock('axios');
+
+describe('api client logout', () => {
+  let post: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    post = vi.fn().mockResolvedValue({ data: { success: true, data: { loggedOut: true } } });
+    vi.mocked(axios.create).mockReturnValue({
+      post,
+      get: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      interceptors: {
+        request: { use: vi.fn() },
+        response: { use: vi.fn() },
+      },
+    } as never);
+  });
+
+  it('posts to /auth/logout', async () => {
+    const client = createAuthenticatedApiClient(() => 'token', () => {});
+
+    await client.logout();
+
+    expect(post).toHaveBeenCalledWith('/auth/logout');
+  });
+
+  it('does not call the sign-out-everywhere endpoint', async () => {
+    const client = createAuthenticatedApiClient(() => 'token', () => {});
+    const del = vi.mocked(axios.create).mock.results[0].value.delete;
+
+    await client.logout();
+
+    // Signing out of this browser must not sign the user's phone out too.
+    expect(del).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -235,6 +235,19 @@ class TokenAwareApiClient {
   }
 
   /**
+   * `POST /auth/logout` -- end THIS browser's session and clear its cookie.
+   *
+   * Distinct from revokeAllSessions(): ordinary sign-out must not sign the
+   * user's other devices out. Before this existed, signing out cleared only
+   * local state while the httpOnly cookie and its server-side session
+   * survived, so the next page load silently signed the user back in.
+   */
+  async logout(): Promise<ApiResponse<{ loggedOut: boolean }>> {
+    const response = await this.api.post('/auth/logout');
+    return response.data;
+  }
+
+  /**
    * `GET /auth/session-health` -- check session validity and expiration info.
    * Used to show refresh warnings before the session expires.
    */


### PR DESCRIPTION
Webapp half of the "sign out doesn't sign you out" fix. Pairs with tangentialism/yeezles-todo#7, which adds the endpoint.

## Why

Confirmed against production during passkey Phase 2 testing: **"log out and back in" left you signed in.** `logout()` never told the server, so the httpOnly `__Host-remember_token` cookie and its session survived, and the next page load silently restored the user as `persistent-session`.

That left a **90-day session behind on a shared machine**, and it made **passkey enrollment permanently unreachable** — a cookie-restored user never holds the Google ID token enrollment requires, and had no way to obtain one. It is why enrollment kept 403-ing even after the Bearer-token fix shipped, and why enrolling only worked in an incognito window.

## Design notes worth reviewing

- **Called unconditionally**, not only when `hasPersistentSession` is true. That flag reflects what *this tab* believes; the cookie can outlive the belief. The endpoint is a no-op without a cookie.
- **Not `revokeAllSessions()`.** Signing out of this browser must not sign the user's phone out — that distinction is the entire reason the new endpoint exists.
- **A failed round trip is logged and swallowed**, local state clears regardless. A network error must not strand someone in a signed-in browser. This also means **the webapp degrades gracefully if it ships before the backend**: the call 404s, is caught, and logout behaves exactly as it does today.

## Verification

Four tests, **each watched failing first**. Both new files are separate from `api.test.ts` and `AuthContext.test.tsx` deliberately — those carry pre-existing failures (axios `interceptors` undefined; real network calls escaping into jsdom), and this behaviour should not be reported through an already-red harness.

| Mutation | Result |
|---|---|
| Remove the `logout()` call | 2 tests redden |
| Swap it for `revokeAllSessions()` | 2 tests redden |

- `tsc -b --noEmit` exit 0.
- Webapp suite: **63 failures before, 63 after** — no regressions. Total 238 → 242, passing 175 → 179, exactly the four added.

**Not verified:** that sign-out now behaves correctly in a real browser. That needs both halves deployed.

## Deploy order

Backend first, then webapp. Reversed is safe (the call 404s and is caught); it just doesn't fix anything until the backend lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvhA2Ja2w3W7oBF8ZDJCYz
